### PR TITLE
Change `sum` variable to `total`

### DIFF
--- a/m03-smallworld/m03_pathlength.ipynb
+++ b/m03-smallworld/m03_pathlength.ipynb
@@ -501,9 +501,9 @@
    ],
    "source": [
     "%%timeit\n",
-    "sum = 0\n",
+    "total = 0\n",
     "for i in range(1000000):\n",
-    "    sum += i\n",
+    "    total += i\n",
     "  "
    ]
   },
@@ -540,9 +540,9 @@
    ],
    "source": [
     "%%time\n",
-    "sum = 0\n",
+    "total = 0\n",
     "for i in range(1000000):\n",
-    "    sum += i"
+    "    total += i"
    ]
   },
   {


### PR DESCRIPTION
Using `sum` as a variable name overrides the builtin `sum` python function. This prevents it from working in the entire notebook once the cell has run.